### PR TITLE
index.htmの隋拼正書法をv2022.04.01に更新します

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -398,7 +398,7 @@
         <td class="蟹">&acirc;i</td>
         <td class="蟹">u&acirc;i</td>
         <td class="蟹">i&acirc;i</td>
-        <td></td>
+        <td class="蟹">y&acirc;i</td>
         <td class="蟹">&#601;i</td>
         <td></td>
         <td></td>
@@ -406,7 +406,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">y&ocirc;i</td>
+        <td></td>
         <td class="蟹">ui</td>
         <td class="止">yui</td>
         <td class="止">ri</td>
@@ -428,7 +428,7 @@
         <td class="蟹">泰開</td>
         <td class="蟹">泰合</td>
         <td class="蟹">廃開</td>
-        <td></td>
+        <td class="蟹">廃合</td>
         <td class="蟹">&#21645;</td>
         <td></td>
         <td></td>
@@ -436,7 +436,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">廃合</td>
+        <td></td>
         <td class="蟹">灰</td>
         <td class="止">微合</td>
         <td class="止">脂B開</td>
@@ -458,7 +458,7 @@
         <td class="蟹">ai</td>
         <td class="蟹">uei</td>
         <td class="蟹">i</td>
-        <td></td>
+        <td class="蟹">uei</td>
         <td class="蟹">ai</td>
         <td></td>
         <td></td>
@@ -466,7 +466,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">uei</td>
+        <td></td>
         <td class="蟹">uei</td>
         <td class="止">uei (uai)</td>
         <td class="止">er [i]</td>
@@ -500,7 +500,7 @@
           ng: oi<br>
           K: ui</td>
         <td class="蟹">ai</td>
-        <td></td>
+        <td class="蟹">ai</td>
         <td class="蟹">oi</td>
         <td></td>
         <td></td>
@@ -512,7 +512,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">ai</td>
+        <td></td>
 
         <td class="蟹">ui</td>
 
@@ -547,7 +547,7 @@
         <td class="蟹">ai<br>m/n/ŋ: ainn</td>
         <td class="蟹">ue</td>
         <td class="蟹">ue</td>
-        <td></td>
+        <td class="蟹">ue</td>
         <td class="蟹">ai<br>P/C: ai, ainn</td>
         <td></td>
         <td></td>
@@ -555,7 +555,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">ue</td>
+        <td></td>
         <td class="蟹">P: ue<br>m: uinn<br>D/K: ui, ue</td>
         <td class="止">ui<br>my: i, ui</td>
         <td class="止">i<br>S: i, u<br>Sr: i, u, e<br>nь: i, inn</td>
@@ -577,7 +577,7 @@
         <td class="蟹">ae</td>
         <td class="蟹">oe</td>
         <td class="蟹">ye</td>
-        <td></td>
+        <td class="蟹">we</td>
         <td class="蟹">ae</td>
         <td></td>
         <td></td>
@@ -585,7 +585,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">we</td>
+        <td></td>
         <td class="蟹">oe</td>
         <td class="止">wi</td>
         <td class="止">PTK: i<br>CS: a</td>
@@ -607,7 +607,7 @@
         <td class="蟹">ai</td>
         <td class="蟹">ai, [wai]</td>
         <td class="蟹">ye</td>
-        <td></td>
+        <td class="蟹">ai [wai]</td>
         <td class="蟹">ai</td>
         <td></td>
         <td></td>
@@ -615,7 +615,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">ai [wai]</td>
+        <td></td>
         <td class="蟹">ai, [wai]</td>
         <td class="止">P: i<br>D: ui<br>K: i, wi<br>j: vi</td>
         <td class="止">i</td>
@@ -637,7 +637,7 @@
         <td class="蟹">ai [ai e]</td>
         <td class="蟹">P/S: ai<br>K: we<br>T/l: ai, ui, a</td>
         <td class="蟹">ai</td>
-        <td></td>
+        <td class="蟹">廃合</td>
         <td class="蟹">ai [ai e]</td>
         <td></td>
         <td></td>
@@ -645,7 +645,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="蟹">廃合</td>
+        <td></td>
         <td class="蟹">P/S: ai<br>K: we<br>T/l: ai, ui, a</td>
         <td class="止">P: i<br>K: wi<br>D: ui<br>j: yui</td>
         <td class="止">i<br>Sr/S/Tь/Nь: i, e</td>
@@ -668,7 +668,7 @@
         <td class="山">an</td>
         <td class="山">uan</td>
         <td class="臻">ian</td>
-        <td></td>
+        <td class="臻">yan</td>
         <td class="臻">&#601;n</td>
         <td></td>
         <td></td>
@@ -676,7 +676,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">yon</td>
+        <td></td>
         <td class="臻">un</td>
         <td class="臻">yun</td>
         <td class="臻">rin</td>
@@ -698,7 +698,7 @@
         <td class="山">寒</td>
         <td class="山">桓</td>
         <td class="臻">元開</td>
-        <td></td>
+        <td class="臻">元合</td>
         <td class="臻">痕</td>
         <td></td>
         <td></td>
@@ -706,7 +706,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">元合</td>
+        <td></td>
         <td class="臻">魂</td>
         <td class="臻">文</td>
         <td class="臻">真B開/臻</td>
@@ -728,7 +728,7 @@
         <td class="山">an</td>
         <td class="山">uan</td>
         <td class="臻">ian</td>
-        <td></td>
+        <td class="臻">&uuml;an</td>
         <td class="臻">uen [en]</td>
         <td></td>
         <td></td>
@@ -736,7 +736,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">&uuml;an</td>
+        <td></td>
         <td class="臻">uen</td>
         <td class="臻">uen</td>
         <td class="臻">en</td>
@@ -760,16 +760,16 @@
         <td class="山">D: yun<br>
           K: un</td>
         <td class="臻">in</td>
-        <td></td>
-        <td class="臻">an</td>
-        <td></td>
-        <td></td>
-        <td class="臻">an</td>
-        <td></td>
-        <td></td>
-        <td></td>
         <td class="臻">P: aan<br>
           D: K: yun</td>
+        <td class="臻">an</td>
+        <td></td>
+        <td></td>
+        <td class="臻">an</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td class="臻">yun</td>
         <td class="臻">an</td>
         <td class="臻">an</td>
@@ -793,7 +793,7 @@
         <td class="山">an</td>
         <td class="山">uan, 'uan an'</td>
         <td class="臻">ian</td>
-        <td></td>
+        <td class="臻">uan 'an'</td>
         <td class="臻">un, in</td>
         <td></td>
         <td></td>
@@ -801,7 +801,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">uan 'an'</td>
+        <td></td>
         <td class="臻">un</td>
         <td class="臻">un</td>
         <td class="臻">in [in un]</td>
@@ -823,7 +823,7 @@
         <td class="山">an</td>
         <td class="山">wan</td>
         <td class="臻">eon<br>P: eon</td>
-        <td></td>
+        <td class="臻">won</td>
         <td class="臻">eun</td>
         <td></td>
         <td></td>
@@ -831,7 +831,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">won</td>
+        <td></td>
         <td class="臻">PTC: un, on<br>SK: on</td>
         <td class="臻">un</td>
         <td class="臻">PTCS: in<br>K: eun</td>
@@ -853,7 +853,7 @@
         <td class="山">an</td>
         <td class="山">wan</td>
         <td class="臻"></td>
-        <td></td>
+        <td class="臻">won</td>
         <td class="臻">on</td>
         <td></td>
         <td></td>
@@ -861,7 +861,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">won</td>
+        <td></td>
         <td class="臻">on, q: von</td>
         <td class="臻">un</td>
         <td class="臻">in</td>
@@ -883,7 +883,7 @@
         <td class="山">an</td>
         <td class="山">an [wan]</td>
         <td class="臻">on, an, en</td>
-        <td></td>
+        <td class="臻">P: on, an, en<br>K: won, wan, wen</td>
         <td class="臻">on</td>
         <td></td>
         <td></td>
@@ -891,7 +891,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">P: on, an, en<br>K: won, wan, wen</td>
+        <td></td>
         <td class="臻">P/K/T/l: on<br>S: on, un<br>q: von, un</td>
         <td class="臻">P: un, on<br>m: on<br>K: un</td>
         <td class="臻">in [on]</td>
@@ -914,7 +914,7 @@
         <td class="山">at</td>
         <td class="山">uat</td>
         <td class="臻">iat</td>
-        <td></td>
+        <td class="臻">yat</td>
         <td class="臻">&#601;t</td>
         <td></td>
         <td></td>
@@ -922,7 +922,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">yot</td>
+        <td></td>
         <td class="臻">ut</td>
         <td class="臻">yut</td>
         <td class="臻">rit</td>
@@ -944,7 +944,7 @@
         <td class="山">寒</td>
         <td class="山">桓</td>
         <td class="臻">元開</td>
-        <td></td>
+        <td class="臻">元合</td>
         <td class="臻">痕</td>
         <td></td>
         <td></td>
@@ -952,7 +952,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">元合</td>
+        <td></td>
         <td class="臻">魂</td>
         <td class="臻">文</td>
         <td class="臻">真B開/臻</td>
@@ -974,7 +974,7 @@
         <td class="山">a [e]</td>
         <td class="山"></td>
         <td class="臻">ie</td>
-        <td></td>
+        <td class="臻">a [&uuml;e]</td>
         <td class="臻">e</td>
         <td></td>
         <td></td>
@@ -982,7 +982,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">a [&uuml;e]</td>
+        <td></td>
         <td class="臻">u 'o'</td>
         <td class="臻">&uuml;</td>
         <td class="臻">e</td>
@@ -1006,16 +1006,16 @@
         <td class="山">D: yut<br>
           K: ut</td>
         <td class="臻">it</td>
-        <td></td>
-        <td class="臻">at</td>
-        <td></td>
-        <td></td>
-        <td class="臻">at</td>
-        <td></td>
-        <td></td>
-        <td></td>
         <td class="臻">P: aat<br>
           D: K: yut</td>
+        <td class="臻">at</td>
+        <td></td>
+        <td></td>
+        <td class="臻">at</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td class="臻">yut</td>
         <td class="臻">at</td>
         <td class="臻">at</td>
@@ -1039,7 +1039,7 @@
         <td class="山">at</td>
         <td class="山">uat</td>
         <td class="臻">iat</td>
-        <td></td>
+        <td class="臻">uat</td>
         <td class="臻">ut</td>
         <td></td>
         <td></td>
@@ -1047,7 +1047,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">uat</td>
+        <td></td>
         <td class="臻">ut</td>
         <td class="臻">ut</td>
         <td class="臻">it</td>
@@ -1069,7 +1069,7 @@
         <td class="山">at</td>
         <td class="山">wat</td>
         <td class="臻">eot<br>P: eot</td>
-        <td></td>
+        <td class="臻">wot</td>
         <td class="臻">eut</td>
         <td></td>
         <td></td>
@@ -1077,7 +1077,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">wot</td>
+        <td></td>
         <td class="臻">PTC: ut, ot<br>SK: ot</td>
         <td class="臻">ut</td>
         <td class="臻">PTCS: it<br>K: eut</td>
@@ -1099,7 +1099,7 @@
         <td class="山">atu</td>
         <td class="山">atu [watu]</td>
         <td class="臻">etu</td>
-        <td></td>
+        <td class="臻">atu [wetu]</td>
         <td class="臻">otu</td>
         <td></td>
         <td></td>
@@ -1107,7 +1107,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">atu [wetu]</td>
+        <td></td>
         <td class="臻">otu<br>q: votu</td>
         <td class="臻">utu</td>
         <td class="臻">itu<br>Sr/Tь/S/nь: itu, iti</td>
@@ -1129,7 +1129,7 @@
         <td class="山">atu, ati</td>
         <td class="山">atu [watu]</td>
         <td class="臻">atu</td>
-        <td></td>
+        <td class="臻">P: otu, atu, ati<br>K: woti, watu, wati</td>
         <td class="臻">無</td>
         <td></td>
         <td></td>
@@ -1137,7 +1137,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="臻">P: otu, atu, ati<br>K: woti, watu, wati</td>
+        <td></td>
         <td class="臻">P/K: otu<br>S: otu, oti</td>
         <td class="臻">P: otu, utu<br>m: otu, oti<br>K: utu</td>
         <td class="臻">P/K/Sr/Tь/S/nь: itu, iti<br>K: otu<br>Tr/l: itu</td>
@@ -1331,7 +1331,7 @@
         <td colspan=2 class="咸">ram</td>
         <td colspan=2 class="咸">am</td>
         <td class="咸">iam</td>
-        <td></td>
+        <td class="咸">yam</td>
         <td class="咸">&#601;m</td>
         <td></td>
         <td></td>
@@ -1339,7 +1339,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">yom</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">rim</td>
@@ -1353,7 +1353,7 @@
         <td colspan=2 class="咸">銜</td>
         <td colspan=2 class="咸">談</td>
         <td class="咸">厳</td>
-        <td></td>
+        <td class="咸">凡</td>
         <td class="咸">覃</td>
         <td></td>
         <td></td>
@@ -1361,7 +1361,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">凡</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">侵B</td>
@@ -1375,7 +1375,7 @@
         <td colspan=2 class="咸">an</td>
         <td colspan=2 class="咸">an</td>
         <td class="咸">an [ian]</td>
-        <td></td>
+        <td class="咸">uan</td>
         <td class="咸">an</td>
         <td></td>
         <td></td>
@@ -1383,7 +1383,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">uan</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">in</td>
@@ -1397,7 +1397,7 @@
         <td colspan=2 class="咸">aam</td>
         <td colspan=2 class="咸">aam [am]</td>
         <td class="咸">im</td>
-        <td></td>
+        <td class="咸">aam</td>
         <td class="咸">aam [am]</td>
         <td></td>
         <td></td>
@@ -1405,7 +1405,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">aam</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">am 'an'</td>
@@ -1419,7 +1419,7 @@
         <td colspan=2 class="咸">am</td>
         <td colspan=2 class="咸">am</td>
         <td class="咸">iam</td>
-        <td></td>
+        <td class="咸">uan, ang</td>
         <td class="咸">am</td>
         <td></td>
         <td></td>
@@ -1427,7 +1427,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">uan, ang</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">im, in</td>
@@ -1441,7 +1441,7 @@
         <td colspan=2 class="咸">am</td>
         <td colspan=2 class="咸">am</td>
         <td class="咸">eom</td>
-        <td></td>
+        <td class="咸">eom</td>
         <td class="咸">am</td>
         <td></td>
         <td></td>
@@ -1449,7 +1449,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">eom</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">im</td>
@@ -1463,7 +1463,7 @@
         <td colspan=2 class="咸">am</td>
         <td colspan=2 class="咸">am</td>
         <td class="咸">em</td>
-        <td></td>
+        <td class="咸">am</td>
         <td class="咸">am</td>
         <td></td>
         <td></td>
@@ -1471,7 +1471,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">am</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">im</td>
@@ -1485,7 +1485,7 @@
         <td colspan=2 class="咸">am, em</td>
         <td colspan=2 class="咸">am</td>
         <td class="咸">om, em</td>
-        <td></td>
+        <td class="咸">om</td>
         <td class="咸">K/T/l: am, om<br>S: am</td>
         <td></td>
         <td></td>
@@ -1493,7 +1493,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">om</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">im<br>'om'<br>[om, im]</td>
@@ -1508,7 +1508,7 @@
         <td colspan=2 class="咸">rap</td>
         <td colspan=2 class="咸">ap</td>
         <td class="咸">iap</td>
-        <td></td>
+        <td class="咸">yap</td>
         <td class="咸">&#601;p</td>
         <td></td>
         <td></td>
@@ -1516,7 +1516,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">yop</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">rip</td>
@@ -1530,7 +1530,7 @@
         <td colspan=2 class="咸">銜</td>
         <td colspan=2 class="咸">談</td>
         <td class="咸">厳</td>
-        <td></td>
+        <td class="咸">凡</td>
         <td class="咸">覃</td>
         <td></td>
         <td></td>
@@ -1538,7 +1538,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">凡</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">侵B</td>
@@ -1552,7 +1552,7 @@
         <td colspan=2 class="咸">a [ia]</td>
         <td colspan=2 class="咸">e [a]</td>
         <td class="咸">ie</td>
-        <td></td>
+        <td class="咸">a [ia]</td>
         <td class="咸">a [e]</td>
         <td></td>
         <td></td>
@@ -1560,7 +1560,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">a [ia]</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">i (e)</td>
@@ -1574,7 +1574,7 @@
         <td colspan=2 class="咸">ap</td>
         <td colspan=2 class="咸">aap [ap]</td>
         <td class="咸">ip</td>
-        <td></td>
+        <td class="咸">aap</td>
         <td class="咸">aap [ap]</td>
         <td></td>
         <td></td>
@@ -1582,7 +1582,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">aap</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">ap 'at'</td>
@@ -1596,7 +1596,7 @@
         <td colspan=2 class="咸">ap</td>
         <td colspan=2 class="咸">ap</td>
         <td class="咸">iap</td>
-        <td></td>
+        <td class="咸">uat</td>
         <td class="咸">ap</td>
         <td></td>
         <td></td>
@@ -1604,7 +1604,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">uat</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">ip</td>
@@ -1618,7 +1618,7 @@
         <td colspan=2 class="咸">ap</td>
         <td colspan=2 class="咸">ap</td>
         <td class="咸">eop</td>
-        <td></td>
+        <td class="咸">eop</td>
         <td class="咸">ap</td>
         <td></td>
         <td></td>
@@ -1626,7 +1626,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">eop</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">ip</td>
@@ -1640,7 +1640,7 @@
         <td colspan=2 class="咸">afu</td>
         <td colspan=2 class="咸">afu</td>
         <td class="咸">P: afu<br>K: efu</td>
-        <td></td>
+        <td class="咸">P: afu<br>K: efu</td>
         <td class="咸">afu</td>
         <td></td>
         <td></td>
@@ -1648,7 +1648,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">P: afu<br>K: efu</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">ifu</td>
@@ -1662,7 +1662,7 @@
         <td colspan=2 class="咸">afu, efu</td>
         <td colspan=2 class="咸">afu</td>
         <td class="咸">P: ofu<br>K: ofu, efu</td>
-        <td></td>
+        <td class="咸">P: ofu<br>K: ofu, efu</td>
         <td class="咸">afu [afu, ofu]</td>
         <td></td>
         <td></td>
@@ -1670,7 +1670,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td class="咸">P: ofu<br>K: ofu, efu</td>
+        <td></td>
         <td></td>
         <td></td>
         <td colspan=2 class="深">ifu [ifu, ofu]</td>


### PR DESCRIPTION
以下の韻母の主母音表記が変更になります：

```diff
- yôi
- yon
- yot
- yom
- yop
+ yâi
+ yan
+ yat
+ yam
+ yap
```

この変更に伴い，その他の方言漢字音のセルも移動します。

v2022.04.01では唇音三等B類の表記にも変更がありますが，声母に依存するためindex.htmにその更新はありません。  
また，その他のファイルはすでにv2022.04.01に対応していることを確認しました。